### PR TITLE
Ensure path is a directory before spawning

### DIFF
--- a/bin/lerna-run.js
+++ b/bin/lerna-run.js
@@ -39,6 +39,10 @@ if(cmd.length < 1) process.exit(0);
 each(pkgs, function(pkg, next){
 
   var pkgdir = path.resolve("./packages", pkg);
+  if (!fs.lstatSync(pkgdir).isDirectory()) {
+    return next();
+  }
+
   var _spawn = spawn("sh", ["-c", cmd], {
     cwd: pkgdir,
     stdio: ['pipe', process.stdout, process.stderr],


### PR DESCRIPTION
Fixes issues if there's hidden files in the packages dir, e.g. .DS_Store files on OSX